### PR TITLE
chore: add GitHub issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,30 @@
+---
+name: Bug report
+about: Report a bug in code, notebooks, or data outputs
+title: ''
+labels: bug
+assignees: ''
+---
+
+## Description
+<!-- What's broken? Be specific. -->
+
+## To reproduce
+1.
+2.
+3.
+
+## Expected behavior
+<!-- What should happen? -->
+
+## Actual behavior
+<!-- What happens instead? Paste the error message, traceback, or screenshot. -->
+
+## Environment
+- OS: <!-- macOS / Windows / Linux -->
+- Python version:
+- Install method: <!-- uv / conda / pip -->
+- Affected country / notebook (if applicable):
+
+## Additional context
+<!-- Anything else? Links to related issues, recent changes, etc. -->

--- a/.github/ISSUE_TEMPLATE/chore.md
+++ b/.github/ISSUE_TEMPLATE/chore.md
@@ -1,0 +1,24 @@
+---
+name: Chore
+about: Tooling, infrastructure, docs, or refactor work
+title: ''
+labels: chore
+assignees: ''
+---
+
+## Goal
+<!-- What's the desired end state? -->
+
+## Why
+<!-- Why now? What's the motivation or trigger? -->
+
+## Scope
+<!-- What files / areas will change? -->
+
+## Out of scope
+<!-- What is explicitly NOT part of this work? Link follow-up issues if any. -->
+
+## Acceptance criteria
+- [ ]
+- [ ]
+- [ ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Propose a new feature or enhancement
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+<!-- What problem would this solve? Who is affected? -->
+
+## Proposed solution
+<!-- What do you want to happen? -->
+
+## Alternatives considered
+<!-- What else did you think about? Why not those? -->
+
+## Scope
+<!-- What is in scope, and what is explicitly out of scope? -->
+
+## Additional context
+<!-- Examples, mockups, references, related issues. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+<!-- 1-3 bullets describing what this PR does -->
+-
+
+## Linked issue
+Closes #
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Chore (tooling, docs, refactor)
+- [ ] Data update
+
+## Verification
+<!-- How did you test this? Which notebook(s) ran? Any output diffs to flag? -->
+
+## Notes for reviewer
+<!-- Anything specific to call out: tradeoffs, follow-ups, screenshots of new figures. -->


### PR DESCRIPTION
## Summary
- Add 3 issue templates (bug, feature, chore) and a default PR template
- Disable blank issues to force template selection
- Establishes the foundation for issue-driven workflow going forward

## Linked issue
Closes #98

## Type of change
- [x] Chore (tooling, docs, refactor)

## Verification
- [ ] After merge, "New issue" on GitHub shows the 3-template chooser
- [ ] "New PR" auto-fills the PR template
- [ ] Blank issues are no longer offered

## Notes for reviewer
Kept templates as Markdown (not YAML forms) for editability — easy to upgrade later if we want richer validation. See #98 for full rationale and out-of-scope items (CONTRIBUTING.md, CI workflows).