### PR TITLE
docs: refine v1.2 CHANGELOG summary and README raw-data note

### DIFF
--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -8,15 +8,20 @@ This project follows a dataset-oriented versioning scheme:
 - **Major versions (x.0)** indicate substantial data updates, schema changes, or new raw data sources.
 
 ## [1.2] - 2026-05-05
-**Row counts:** 203,125 (v1.0) → 217,487 (v1.2) | Net +14,362 rows
-**Changes:** 36,800 rows added · 22,438 rows removed · 2,939 rows with revised values (>5%)
-**Countries affected:** Angola, Benin, Burkina Faso, Ethiopia, Kenya, Lesotho, Malawi, Mozambique, Somalia, South Africa, South Sudan, Sudan, Zambia
+
+### Summary
+
+This release improves HarvestStat Africa’s data coverage, boundary consistency, and harmonization. Changes include new and backfilled records, selected re-ingestion of country datasets, and limited corrections or standardization of administrative names, crop names, and values. For most applications, users should use v1.2 as the most complete and current version of the dataset, while consulting the country-specific notes below when comparing results with earlier versions.
+
+- **Row counts:** 203,125 (v1.0) → 217,487 (v1.2) | Net +14,362 rows
+- **Changes:** 36,800 rows added · 22,438 rows removed · 2,939 rows with revised values (>5%)
+- **Countries affected:** Angola, Benin, Burkina Faso, Ethiopia, Kenya, Lesotho, Malawi, Mozambique, Somalia, South Africa, South Sudan, Sudan, Zambia
 
 ### Boundary file
 
-**Admin units:** 1,109 (v1.0) → 1,128 (v1.2) | Net +19 units
-**Schema:** New `country_co` column added in v1.2 containing ISO 2-letter country codes (e.g. `AO`, `ET`) — present for all countries.
-**Countries with changes:** 3
+- **Admin units:** 1,109 (v1.0) → 1,128 (v1.2) | Net +19 units
+- **Schema:** New `country_co` column added in v1.2 containing ISO 2-letter country codes (e.g. `AO`, `ET`) — present for all countries.
+- **Countries with changes:** 3
 
 | Country | Change type | Detail |
 |---|---|---|
@@ -145,7 +150,7 @@ Wholesale re-ingestion: old rows replaced across all affected crops. The crop `P
 
 
 ### South Africa
-Forward extension to 2023–2025 for all existing crops, plus Oats added as a new series (2013–2025). Shared rows show systematic yield corrections of 6–25% for Maize, Soybean, and Wheat across multiple years
+Forward extension to 2023–2025 for all existing crops, plus Oats added as a new series (2013–2025). Shared rows show systematic yield corrections of 6–25% for Maize, Soybean, and Wheat across multiple years.
 
 | Crop | New years |
 |---|---|

--- a/public/README.md
+++ b/public/README.md
@@ -119,10 +119,7 @@ A shapefile version of FEWS NET administrative boundaries.
 The data structure is identical to the GeoPackage file.
 
 ### **fdw_raw_data_v1.2.zip**
-A zipped archive containing raw FEWS NET Data Warehouse (FDW) data
-for 33 Sub-Saharan African countries.
-
-(Individual country CSV files are named using ISO 3166-1 alpha-2 codes.)
+This file is not included in the Dryad dataset. From v1.2 onward, the raw FEWS NET Data Warehouse (FDW) data archive used to develop HarvestStat Africa is provided through the [HarvestStat-Africa GitHub releases](https://github.com/HarvestStat/HarvestStat-Africa/releases) for reference and reproducibility purposes. Individual country CSV files are named using ISO 3166-1 alpha-2 codes.
 
 ---
 
@@ -130,6 +127,12 @@ for 33 Sub-Saharan African countries.
 Please refer to  
 [CHANGELOG.md](https://github.com/HarvestStat/HarvestStat-Africa/blob/main/public/CHANGELOG.md)
 for detailed version history and updates.
+
+---
+
+## Source data and derived dataset note
+
+HarvestStat Africa is a derived, harmonized dataset constructed from multiple original source documents and data products. The harmonized HarvestStat Africa data and boundary files are not a direct redistribution of the original source files or database records. The original source materials used to construct the dataset are listed in Table S1 of the Supplementary Information associated with the HarvestStat Africa paper.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add a `### Summary` subsection to the v1.2 CHANGELOG entry and reformat the row-count/boundary stats as bullet lists; fix a missing period in the South Africa note
- Rewrite the `fdw_raw_data_v1.2.zip` description in README: not part of the Dryad dataset; provided via GitHub releases from v1.2 onward
- Add a "Source data and derived dataset note" section to README

## Linked issue
N/A — follow-up documentation polish on the v1.2 release docs (#113); no tracking issue.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Chore (tooling, docs, refactor)
- [ ] Data update

## Verification
Documentation only — no data files or notebooks changed, so no notebooks were run. Rendered Markdown reviewed; diff limited to `public/CHANGELOG.md` and `public/README.md`.

## Notes for reviewer
Follow-up polish on top of the v1.2 release docs merged in #113. No changes to dataset contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)