### PR TITLE
docs: restore fdw_raw_data_v1.2.zip description in public README

### DIFF
--- a/public/README.md
+++ b/public/README.md
@@ -120,7 +120,10 @@ bundling all shapefile components (`.shp`, `.shx`, `.dbf`, `.prj`, `.cpg`).
 The data structure is identical to the GeoPackage file.
 
 ### **fdw_raw_data_v1.2.zip**
-This file is not included in the Dryad dataset. From v1.2 onward, the raw FEWS NET Data Warehouse (FDW) data archive used to develop HarvestStat Africa is provided through the [HarvestStat-Africa GitHub releases](https://github.com/HarvestStat/HarvestStat-Africa/releases) for reference and reproducibility purposes. Individual country CSV files are named using ISO 3166-1 alpha-2 codes.
+A zipped archive containing raw FEWS NET Data Warehouse (FDW) data
+for 33 Sub-Saharan African countries.
+
+(Individual country CSV files are named using ISO 3166-1 alpha-2 codes.)
 
 ---
 


### PR DESCRIPTION
## Summary
- Revert the `fdw_raw_data_v1.2.zip` File List entry in `public/README.md` from the "not in Dryad / provided via GitHub releases" note (added in #114) back to the standard description, since the raw FDW archive is distributed as before.

## Linked issue
Closes #118

## Type of change
- [ ] Bug fix
- [ ] New feature
- [x] Chore (tooling, docs, refactor)
- [ ] Data update

## Verification
- Diff is limited to the single `fdw_raw_data_v1.2.zip` entry (4 insertions, 1 deletion); no other content changed.

## Notes for reviewer
Documentation-only revert. No data files or notebooks touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)